### PR TITLE
Do not set finish date on completion if create date is missing

### DIFF
--- a/src/task/extended.rs
+++ b/src/task/extended.rs
@@ -18,7 +18,9 @@ impl Extended {
         let today = chrono::Local::now().date().naive_local();
 
         self.finished = true;
-        self.finish_date = Some(today);
+        if self.create_date.is_some() {
+            self.finish_date = Some(today);
+        }
     }
 
     pub fn uncomplete(&mut self) {


### PR DESCRIPTION
According to https://github.com/todotxt/todo.txt#todotxt-format-rules `finish date` must be specified only if `create date` exists.  But The library sets finish date always when `complete` method is called. Added check that `create date` is set before setting `finish date`.

